### PR TITLE
Add database configuration with SQLAlchemy and pydantic-settings

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,0 +1,8 @@
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+class Settings(BaseSettings):
+    ASYNC_DATABASE_URL: str
+
+    model_config = SettingsConfigDict(env_file=".env")
+
+settings = Settings()

--- a/app/db/database.py
+++ b/app/db/database.py
@@ -1,0 +1,22 @@
+from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
+from sqlalchemy.orm import sessionmaker
+from pydantic_settings import BaseSettings
+
+# Load DB URL using pydantic-settings
+class Settings(BaseSettings):
+    ASYNC_DATABASE_URL: str
+
+    class Config:
+        env_file = ".env"  # Reads from .env file in project root
+
+settings = Settings()
+
+# Create async engine
+engine = create_async_engine(settings.ASYNC_DATABASE_URL, echo=True)
+
+# Create session generator
+async_session = sessionmaker(
+    bind=engine,
+    class_=AsyncSession,
+    expire_on_commit=False
+)

--- a/app/db/database.py
+++ b/app/db/database.py
@@ -1,17 +1,8 @@
 from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
 from sqlalchemy.orm import sessionmaker
-from pydantic_settings import BaseSettings
+from app.core.config import settings
 
-# Load DB URL using pydantic-settings
-class Settings(BaseSettings):
-    ASYNC_DATABASE_URL: str
 
-    class Config:
-        env_file = ".env"  # Reads from .env file in project root
-
-settings = Settings()
-
-# Create async engine
 engine = create_async_engine(settings.ASYNC_DATABASE_URL, echo=True)
 
 # Create session generator

--- a/app/db/session.py
+++ b/app/db/session.py
@@ -1,0 +1,8 @@
+from app.db.database import async_session
+from sqlalchemy.ext.asyncio import AsyncSession
+from typing import AsyncGenerator
+
+# Dependency function to provide DB session to routes
+async def get_db() -> AsyncGenerator[AsyncSession, None]:
+    async with async_session() as session:
+        yield session


### PR DESCRIPTION
Load database URL from .env using pydantic-settings.
Create asynchronous SQLAlchemy engine and session generator.
Implement dependency injection for database sessions in FastAPI.
" Moved Settings class to app/core/config.py
Updated to Pydantic v2 using SettingsConfigDict
Cleaned up database.py for better maintainability "