### PR TITLE
feat: : #3 Configure async database connection from .env

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,0 +1,8 @@
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+class Settings(BaseSettings):
+    async_database_url: str
+
+    model_config = SettingsConfigDict(env_file=".env", env_prefix="", case_sensitive=False, extra="allow")
+
+settings = Settings()

--- a/app/db/deps.py
+++ b/app/db/deps.py
@@ -1,0 +1,7 @@
+from collections.abc import AsyncGenerator
+from sqlalchemy.ext.asyncio import AsyncSession
+from app.db.session import AsyncSessionLocal
+
+async def get_db() -> AsyncGenerator[AsyncSession, None]:
+    async with AsyncSessionLocal() as session:
+        yield session

--- a/app/db/session.py
+++ b/app/db/session.py
@@ -1,0 +1,11 @@
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.core.config import settings
+
+engine = create_async_engine(settings.async_database_url, echo=False)
+
+AsyncSessionLocal = async_sessionmaker(
+    bing=engine,
+    class_=AsyncSession,
+    expire_on_commit=False,
+)


### PR DESCRIPTION
Added settings loader for DB URLs using pydantic-settings,
Created async SQLAlchemy engine and session factory,
Added get_db dependency for session injection