### PR TITLE
feat: : #8 Add task CRUD endpoints with JWT auth

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -3,8 +3,10 @@ from fastapi import FastAPI
 app = FastAPI()
 
 from app.routes.auth import router as auth_router
+from app.routes.tasks import router as tasks_router
 
 app.include_router(auth_router)
+app.include_router(tasks_router)
 
 # @app.get("/")
 # async def home():

--- a/app/routes/tasks.py
+++ b/app/routes/tasks.py
@@ -1,0 +1,79 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.auth import get_current_user
+from app.db.deps import get_db
+from app.models.task import Task
+from app.schemas.task import TaskCreate, TaskRead, TaskUpdate
+
+router = APIRouter(prefix="/tasks", tags=["tasks"])
+
+
+@router.post("/", response_model=TaskRead, status_code=status.HTTP_201_CREATED)
+async def create_task(
+    payload: TaskCreate,
+    db: AsyncSession = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
+    task = Task(
+        title=payload.title,
+        description=payload.description,
+        owner_id=current_user.id,
+    )
+    db.add(task)
+    await db.commit()
+    await db.refresh(task)
+    return task
+
+
+@router.get("/", response_model=list[TaskRead])
+async def list_tasks(
+    db: AsyncSession = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
+    result = await db.execute(select(Task).where(Task.owner_id == current_user.id))
+    return result.scalars().all()
+
+
+@router.put("/{task_id}", response_model=TaskRead)
+async def update_task(
+    task_id: int,
+    payload: TaskUpdate,
+    db: AsyncSession = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
+    result = await db.execute(
+        select(Task).where(Task.id == task_id, Task.owner_id == current_user.id)
+    )
+    task = result.scalar_one_or_none()
+    if not task:
+        raise HTTPException(status_code=404, detail="Task not found")
+
+    if payload.title is not None:
+        task.title = payload.title
+    if payload.description is not None:
+        task.description = payload.description
+    if payload.completed is not None:
+        task.completed = payload.completed
+
+    await db.commit()
+    await db.refresh(task)
+    return task
+
+
+@router.delete("/{task_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_task(
+    task_id: int,
+    db: AsyncSession = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
+    result = await db.execute(
+        select(Task).where(Task.id == task_id, Task.owner_id == current_user.id)
+    )
+    task = result.scalar_one_or_none()
+    if not task:
+        raise HTTPException(status_code=404, detail="task not found")
+
+    await db.delete(task)
+    await db.commit()

--- a/app/schemas/task.py
+++ b/app/schemas/task.py
@@ -3,7 +3,7 @@ from pydantic import BaseModel
 
 class TaskCreate(BaseModel):
     title: str
-    desciption: str | None = None
+    description: str | None = None
 
 class TaskRead(BaseModel):
     id: int


### PR DESCRIPTION
Added /tasks CRUD endpoints (create, list, update, delete),
Enforced JWT auth on all task routes,
Scoped task access to current user