### PR TITLE
feat: :sparkles: issue #3 add async DB config, engine, and session dependency

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,0 +1,12 @@
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+class Settings(BaseSettings):
+    sync_database_url: str
+    async_database_url: str
+    jwt_secret_key: str
+    access_token_expire_minutes: int
+    refresh_token_expire_minutes: int
+    jwt_algorithm: str    
+    model_config = SettingsConfigDict(env_file=".env", env_prefix="", case_sensitive=False)
+
+settings = Settings()

--- a/app/db/deps.py
+++ b/app/db/deps.py
@@ -1,0 +1,8 @@
+from typing import AsyncGenerator
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.session import AsyncSessionLocal
+
+async def get_db() -> AsyncGenerator[AsyncSession, None]:
+    async with AsyncSessionLocal() as session:
+        yield session

--- a/app/db/session.py
+++ b/app/db/session.py
@@ -1,0 +1,11 @@
+from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
+from sqlalchemy.orm import sessionmaker
+
+from app.core.config import settings
+
+engine = create_async_engine(settings.async_database_url, echo=False, future=True)
+AsyncSessionLocal = sessionmaker(
+    bind=engine,
+    class_=AsyncSession,
+    expire_on_commit=False,
+)


### PR DESCRIPTION
This PR adds database configuration using pydantic-settings, creates the async SQLAlchemy engine and session factory, and provides a get_db dependency for FastAPI routes. It standardizes DB access patterns and ensures settings are loaded from .env in a type‑safe way.