### PR TITLE
feat: :sparkles: issue #6 add login and JWT auth helpers

### DIFF
--- a/app/core/deps.py
+++ b/app/core/deps.py
@@ -1,0 +1,41 @@
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+from jose import JWTError, jwt
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.db.deps import get_db
+from app.schemas.token import TokenData
+from app.services.user_service import get_user_by_username
+from app.schemas.token import TokenData
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/login")
+
+async def get_current_user(
+    token: str = Depends(oauth2_scheme),
+    db: AsyncSession = Depends(get_db),
+):
+    try:
+        payload = jwt.decode(
+            token,
+            settings.jwt_secret_key,
+            algorithms=[settings.jwt_algorithm],
+        )
+        username: str | None = payload.get("sub")
+        token_data = TokenData(username=username)
+
+        if token_data.username is None:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid token",
+            )
+    except JWTError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid token",
+        )
+
+    user = await get_user_by_username(db, username)
+    if user is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found")
+    return user

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -1,4 +1,8 @@
 from passlib.context import CryptContext
+from datetime import datetime, timedelta, timezone
+from jose import JWTError, jwt
+
+from app.core.config import settings
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
@@ -7,3 +11,9 @@ def hash_password(password: str) -> str:
 
 def verify_password(password: str, hashed_password: str) -> bool:
     return pwd_context.verify(password, hashed_password)
+
+def create_access_token(data: dict, expires_minutes:int) -> str:
+    to_encode = data.copy()
+    expire = datetime.now(timezone.utc)+timedelta(minutes=expires_minutes)
+    to_encode.update({"exp":expire})
+    return jwt.encode(to_encode, settings.jwt_secret_key, algorithm=settings.jwt_algorithm)

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -1,9 +1,13 @@
 from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordRequestForm
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.deps import get_db
 from app.schemas.user import UserCreate, UserRead
-from app.services.user_service import create_user, get_user_by_username
+from app.schemas.token import Token
+from app.services.user_service import create_user, get_user_by_username, get_user_by_username
+from app.core.security import verify_password, create_access_token
+from app.core.config import settings
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
@@ -17,4 +21,15 @@ async def register(user_in: UserCreate, db: AsyncSession = Depends(get_db)):
         )
     user = await create_user(db, user_in)
     return user
+
+@router.post("/login", response_model=Token)
+async def login(form_data: OAuth2PasswordRequestForm = Depends(), db: AsyncSession = Depends(get_db)):
+    user = await get_user_by_username(db,form_data.username)
+    if not user or not verify_password(form_data.password, user.hashed_password):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
     
+    access_token = create_access_token(
+        data={"sub":user.username},
+        expires_minutes=settings.access_token_expire_minutes,
+    )
+    return {"access_token":access_token, "token_type":"bearer"}

--- a/app/schemas/token.py
+++ b/app/schemas/token.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+class Token(BaseModel):
+    access_token: str 
+    token_type: str = "bearer"
+
+class TookenData(BaseModel):
+    username: str | None = None

--- a/app/schemas/token.py
+++ b/app/schemas/token.py
@@ -4,5 +4,5 @@ class Token(BaseModel):
     access_token: str 
     token_type: str = "bearer"
 
-class TookenData(BaseModel):
+class TokenData(BaseModel):
     username: str | None = None

--- a/poetry.lock
+++ b/poetry.lock
@@ -1112,6 +1112,18 @@ pycryptodome = ["pycryptodome (>=3.3.1,<4.0.0)"]
 test = ["pytest", "pytest-cov"]
 
 [[package]]
+name = "python-multipart"
+version = "0.0.22"
+description = "A streaming multipart parser for Python"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155"},
+    {file = "python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58"},
+]
+
+[[package]]
 name = "rsa"
 version = "4.2"
 description = "Pure-Python RSA implementation"
@@ -1306,4 +1318,4 @@ standard = ["colorama (>=0.4) ; sys_platform == \"win32\"", "httptools (>=0.6.3)
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.14"
-content-hash = "4593a7c940a113bb8a2dd92edd42cb04eba0bf0cec3e2bc7c6af08eb56c34fa1"
+content-hash = "979448ad7cbc303a02a3e7e7214e7894e33efde86a0d430e06958e2a2cf283c9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,8 @@ dependencies = [
     "python-jose[cryptography] (>=3.5.0,<4.0.0)",
     "passlib[bcrypt] (>=1.7.4,<2.0.0)",
     "pydantic-settings (>=2.13.1,<3.0.0)",
-    "bcrypt (<4)"
+    "bcrypt (<4)",
+    "python-multipart (>=0.0.22,<0.0.23)"
 ]
 
 


### PR DESCRIPTION
This PR adds JWT‑based authentication by introducing token schemas, JWT creation utilities, the /auth/login endpoint using OAuth2 form data, and a get_current_user dependency for protected routes. It wires configuration values from .env and enables password verification with hashed passwords. Testing was done by starting the server and hitting /auth/login with valid credentials.