### PR TITLE
feat: :sparkles: issue #8 add CRUD endpoints for tasks with JWT auth

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,8 +1,12 @@
 from fastapi import FastAPI
 from app.routes.auth import router as auth_router
+from app.routes.tasks import router as tasks_router
+
 app = FastAPI(title = "ToDo API")
 
 app.include_router(auth_router)
+app.include_router(tasks_router)
+
 
 @app.get("/")
 async def root():

--- a/app/routes/tasks.py
+++ b/app/routes/tasks.py
@@ -1,0 +1,55 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.deps import get_current_user
+from app.db.deps import get_db
+from app.models.user import User
+from app.schemas.task import TaskCreate, TaskRead, TaskUpdate
+from app.services.task_service import (
+    create_task,
+    get_tasks_for_user,
+    get_task_by_id,
+    update_task,
+    delete_task,
+)
+
+router = APIRouter(prefix="/tasks", tags=["tasks"])
+
+@router.post("/", response_model=TaskRead, status_code=status.HTTP_201_CREATED)
+async def create_task_route(
+    task_in: TaskCreate,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    return await create_task(db, current_user.id, task_in)
+
+@router.get("/", response_model=list[TaskRead])
+async def list_tasks_route(
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    return await get_tasks_for_user(db, current_user.id)
+
+@router.put("/{task_id}", response_model=TaskRead)
+async def update_task_route(
+    task_id: int,
+    task_in: TaskUpdate,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    task = await get_task_by_id(db, task_id, current_user.id)
+    if not task:
+        raise HTTPException(status_code=404, detail="Task not found")
+    return await update_task(db, task, task_in)
+
+@router.delete("/{task_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_task_route(
+    task_id: int,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    task = await get_task_by_id(db, task_id, current_user.id)
+    if not task:
+        raise HTTPException(status_code=404, detail="Task not found")
+    await delete_task(db, task)
+    return None

--- a/app/services/task_service.py
+++ b/app/services/task_service.py
@@ -1,0 +1,43 @@
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.task import Task
+from app.schemas.task import TaskCreate, TaskUpdate
+
+async def create_task(db: AsyncSession, owner_id: int, task_in: TaskCreate) -> Task:
+    task = Task(
+        title=task_in.title,
+        description=task_in.description,
+        completed=task_in.completed,
+        owner_id=owner_id,
+    )
+    db.add(task)
+    await db.commit()
+    await db.refresh(task)
+    return task
+
+async def get_tasks_for_user(db: AsyncSession, owner_id: int) -> list[Task]:
+    result = await db.execute(select(Task).where(Task.owner_id == owner_id))
+    return list(result.scalars().all())
+
+async def get_task_by_id(db: AsyncSession, task_id: int, owner_id: int) -> Task | None:
+    result = await db.execute(
+        select(Task).where(Task.id == task_id, Task.owner_id == owner_id)
+    )
+    return result.scalar_one_or_none()
+
+async def update_task(db: AsyncSession, task: Task, task_in: TaskUpdate) -> Task:
+    if task_in.title is not None:
+        task.title = task_in.title
+    if task_in.description is not None:
+        task.description = task_in.description
+    if task_in.completed is not None:
+        task.completed = task_in.completed
+
+    await db.commit()
+    await db.refresh(task)
+    return task
+
+async def delete_task(db: AsyncSession, task: Task) -> None:
+    await db.delete(task)
+    await db.commit()


### PR DESCRIPTION
This PR adds task CRUD endpoints (POST /tasks, GET /tasks, PUT /tasks/{id}, DELETE /tasks/{id}) protected by JWT authentication. It introduces a task service layer for database operations, ensures tasks are scoped to the current user, and wires the task router into the FastAPI app. Testing was done by creating, listing, updating, and deleting tasks using a valid access token.