### PR TITLE
chore: issue #9 add Dockerfile and docker-compose for app and postgres

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.venv
+__pycache__
+*.pyc
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.14
+
+WORKDIR /app
+
+RUN pip install poetry
+
+COPY pyproject.toml poetry.lock ./
+RUN poetry config virtualenvs.create false && poetry install --no-root
+
+COPY . .
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -3,10 +3,15 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 class Settings(BaseSettings):
     sync_database_url: str
     async_database_url: str
+
+    postgres_user: str
+    postgres_password: str
+    postgres_db: str
+
     jwt_secret_key: str
     access_token_expire_minutes: int
     refresh_token_expire_minutes: int
     jwt_algorithm: str    
-    model_config = SettingsConfigDict(env_file=".env", env_prefix="", case_sensitive=False)
+    model_config = SettingsConfigDict(env_file=".env", env_prefix="", case_sensitive=False, extra="allow")
 
 settings = Settings()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+services:
+  db:
+    image: postgres:16
+    container_name: todo_db
+    restart: always
+    env_file:
+      - .env
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+  web:
+    build: .
+    container_name: todo_api
+    restart: always
+    env_file:
+      - .env
+    depends_on:
+      - db
+    ports:
+      - "8000:8000"
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
 This PR adds Docker support for the FastAPI backend using Poetry, including a Dockerfile, docker-compose.yml for running the API alongside PostgreSQL, and a .dockerignore to keep images clean. It also updates environment variables to support containerized DB configuration and confirms the app runs successfully via docker compose up --build.