### PR TITLE
test: issue #10 add basic auth and task API tests

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -8,6 +8,8 @@ class Settings(BaseSettings):
     postgres_password: str
     postgres_db: str
 
+    test_db_url: str
+
     jwt_secret_key: str
     access_token_expire_minutes: int
     refresh_token_expire_minutes: int

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_mode = auto

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,47 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import pytest_asyncio
+from httpx import AsyncClient, ASGITransport
+from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
+from sqlalchemy.orm import sessionmaker
+
+from app.main import app
+from app.db.base import Base
+from app.db.deps import get_db
+from app.core.config import settings
+from sqlalchemy.pool import NullPool
+
+TEST_DB_URL = settings.test_db_url
+
+@pytest_asyncio.fixture(scope="session")
+async def async_engine():
+    engine = create_async_engine(TEST_DB_URL, future=True, poolclass=NullPool)
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    yield engine
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+    await engine.dispose()
+
+@pytest_asyncio.fixture
+async def client(async_engine):
+    AsyncSessionTest = sessionmaker(bind=async_engine, class_=AsyncSession, expire_on_commit=False)
+
+    async def override_get_db():
+        async with AsyncSessionTest() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = override_get_db
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+    app.dependency_overrides.clear()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,31 @@
+import pytest
+
+@pytest.mark.asyncio
+async def test_register_user(client):
+    payload = {
+        "username": "testuser",
+        "fullname": "Test User",
+        "password": "secret123"
+    }
+    resp = await client.post("/auth/register", json=payload)
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["username"] == "testuser"
+    assert "id" in data
+
+@pytest.mark.asyncio
+async def test_login_user(client):
+    await client.post("/auth/register", json={
+        "username": "loginuser",
+        "fullname": "Login User",
+        "password": "secret123"
+    })
+
+    resp = await client.post("/auth/login", data={
+        "username": "loginuser",
+        "password": "secret123"
+    })
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "access_token" in data
+    assert data["token_type"] == "bearer"

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,0 +1,28 @@
+import pytest
+
+@pytest.mark.asyncio
+async def test_create_and_list_tasks(client):
+    await client.post("/auth/register", json={
+        "username": "taskuser",
+        "fullname": "Task User",
+        "password": "secret123"
+    })
+
+    login = await client.post("/auth/login", data={
+        "username": "taskuser",
+        "password": "secret123"
+    })
+    token = login.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    resp = await client.post("/tasks/", json={
+        "title": "Test Task",
+        "description": "Test Description",
+        "completed": False
+    }, headers=headers)
+    assert resp.status_code == 201
+
+    resp = await client.get("/tasks/", headers=headers)
+    assert resp.status_code == 200
+    tasks = resp.json()
+    assert len(tasks) >= 1


### PR DESCRIPTION
This PR adds basic async test coverage for user registration, login/token generation, and task create/list flows using pytest, pytest‑asyncio, and httpx.AsyncClient. It introduces a test database configuration via TEST_DB_URL, overrides the app’s DB dependency for isolation, and ensures tests run cleanly against a dedicated test database. Tests were executed successfully with pytest.